### PR TITLE
fix address check

### DIFF
--- a/DigiID.php
+++ b/DigiID.php
@@ -158,7 +158,8 @@ class DigiID {
     public function isMessageSignatureValid($address, $signature, $message, $testnet = false) {
         // extract parameters
         $address = $this->_base58check_decode($address, $testnet);
-        if (strlen($address) != 21 || ($address[0] != "\x0" && !$testnet) || ($address[0] != "\x6F" && $testnet)) {
+        
+        if (!$this->isAddressValid($address, $testnet)) {
             throw new InvalidArgumentException('invalid DigiByte address');
         }
 

--- a/DigiID.php
+++ b/DigiID.php
@@ -159,7 +159,7 @@ class DigiID {
         // extract parameters
         $address = $this->_base58check_decode($address, $testnet);
         
-        if (!$this->isAddressValid($address, $testnet)) {
+        if (strlen($address) != 21 || ($address[0] != "\x1E" AND !$testnet) || ($address[0] != "\x6F" AND $testnet)) {
             throw new InvalidArgumentException('invalid DigiByte address');
         }
 

--- a/DigiID.php
+++ b/DigiID.php
@@ -158,7 +158,6 @@ class DigiID {
     public function isMessageSignatureValid($address, $signature, $message, $testnet = false) {
         // extract parameters
         $address = $this->_base58check_decode($address, $testnet);
-        
         if (strlen($address) != 21 || ($address[0] != "\x1E" AND !$testnet) || ($address[0] != "\x6F" AND $testnet)) {
             throw new InvalidArgumentException('invalid DigiByte address');
         }

--- a/DigiID.php
+++ b/DigiID.php
@@ -121,7 +121,7 @@ class DigiID {
         } catch(InvalidArgumentException $e) {
             return false;
         }
-        if (strlen($address) != 21 || ($address[0] != "\x1E" AND !$testnet) || ($address[0] != "\x6F" AND $testnet)) {
+        if (strlen($address) != 21 || ($address[0] != "\x1E" && !$testnet) || ($address[0] != "\x6F" && $testnet)) {
             return false;
         }
         return true;

--- a/callback.php
+++ b/callback.php
@@ -30,7 +30,7 @@ if($post_data!==null) {
 
 // ALL THOSE VARIABLES HAVE TO BE SANITIZED !
 
-$signValid = $digiid->isMessageSignatureValidSafe(@$variables['address'], @$variables['signature'], @$variables['uri'], true);
+$signValid = $digiid->isMessageSignatureValidSafe(@$variables['address'], @$variables['signature'], @$variables['uri']);
 $nonce = $digiid->extractNonce($variables['uri']);
 if($signValid && $dao->checkNonce($nonce) && ($digiid->buildURI(SERVER_URL . 'callback.php', $nonce) === $variables['uri'])) {
     $dao->update($nonce, $variables['address']);


### PR DESCRIPTION
Earlier was $address[0] != "\x0", but it's must be $address[0] != "\x1E"
Else checking adress and login is failed on the server side, and digi-id don't work.